### PR TITLE
bugfix: undefined template instantiation

### DIFF
--- a/src/name_format.h
+++ b/src/name_format.h
@@ -34,6 +34,7 @@
 #ifndef LIBDCP_NAME_FORMAT
 #define LIBDCP_NAME_FORMAT
 
+#include <string>
 #include <boost/optional.hpp>
 #include <map>
 #include <list>


### PR DESCRIPTION
Resolves the following compile error

```
In file included from ../src/name_format.cc:34:
../src/name_format.h:66:14: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
        std::string _specification;
                    ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
In file included from ../src/name_format.cc:34:
../src/name_format.h:49:26: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
        NameFormat (std::string specification)
                                ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
In file included from ../src/name_format.cc:34:
../src/name_format.h:53:14: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
        std::string specification () const {
                    ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
In file included from ../src/name_format.cc:34:
../src/name_format.h:57:38: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
        void set_specification (std::string specification) {
                                            ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
../src/name_format.cc:56:1: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
filter (string c)
^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
../src/name_format.cc:56:16: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
filter (string c)
               ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
../src/name_format.cc:58:9: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
        string o;
               ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
../src/name_format.cc:68:13: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
NameFormat::get (Map values, string suffix) const
            ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
../src/name_format.cc:68:37: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
NameFormat::get (Map values, string suffix) const
                                    ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
../src/name_format.cc:70:9: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
        string result;
               ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
In file included from ../src/name_format.cc:34:
In file included from ../src/name_format.h:38:
In file included from /usr/local/opt/boost/include/boost/optional.hpp:15:
In file included from /usr/local/opt/boost/include/boost/optional/optional.hpp:31:
In file included from /usr/local/opt/boost/include/boost/core/swap.hpp:26:
/usr/local/opt/llvm/bin/../include/c++/v1/utility:325:9: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    _T2 second;
        ^
/usr/local/opt/llvm/bin/../include/c++/v1/map:667:16: note: in instantiation of template class 'std::__1::pair<const char, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >' requested here
    value_type __cc;
               ^
../src/name_format.cc:75:10: note: in instantiation of template class 'std::__1::__value_type<char, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >' requested here
                        if (j != values.end()) {
                              ^
/usr/local/opt/llvm/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
```