### PR TITLE
OpenMP selectable library + readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 libdcp
 ======
 
-Hello.
+Library for reading and writing Digital Cinema Packages (DCPs).
 
 
 Acknowledgements
@@ -17,20 +17,73 @@ Bugfixes were received from Philip Tschiemer.
 Building
 ========
 
-    ./waf configure
-    ./waf
-    sudo ./waf install
+```
+  ./waf configure
+  ./waf
+  sudo ./waf install
+```
 
 
 Dependencies
-============
+--------
 
-boost filesystem, signals2 and unit testing libraries
-openssl
-libsigc++
-libxml++
-xmlsec
-openjpeg (1.5.0 or above)
+- pkg-config (for build system)
+- boost (1.45 or above): filesystem, signals2, datetime and unit testing libraries
+- openssl
+- libsigc++
+- libxml++
+- xmlsec
+- ImageMagick or GraphicsMagick
+- sndfile
+- openjpeg (1.5.0 or above)
+- [libasdcp-cth](https://github.com/cth103/asdcplib-cth/tree/cth)
+- [libcxml](https://github.com/cth103/libcxml)
+- (optional) OpenMP
+- (optional) gcov (for tests)
+
+
+Build options
+---------
+```
+  --target-windows      set up to do a cross-compile to Windows
+  --enable-debug        build with debugging information and without optimisation
+  --static              build libdcp statically, and link statically to openjpeg, cxml, asdcplib-cth
+  --disable-tests       disable building of tests
+  --disable-gcov        dont use gcov in tests
+  --disable-examples    disable building of examples
+  --enable-openmp       enable use of OpenMP
+  --openmp=OPENMP       Specify OpenMP Library to use: omp, gomp (default), iomp..
+  --jpeg=JPEG           specify JPEG library to build with: oj1 or oj2 for OpenJPEG 1.5.x or OpenJPEG 2.1.x respectively
+  --force-cpp11         force use of C++11
+```
+
+A note on building for macOS
+--------
+As goto solution, all dependencies can be installed using [Homebrew](https://brew.sh/).
+Make sure to add the respective `PKG_CONFIG_PATH` paths so the packages are indeed found.
+
+```bash
+## Default Homebrew paths
+PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig"
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/pangomm/lib/pkgconfig"
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libffi/lib/pkgconfig" # needed by gobject2
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig"
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libxml2/lib/pkgconfig"
+
+## Set as installed
+# PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/path-to-your-install-folder/libasdcp-cth"
+# PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/path-to-your-install-folder/libcxml"
+
+export PKG_CONFIG_PATH
+```
+
+If you want support for *OpenMP*, the standard llvm compiler coming with Xcode (or rather its command line tools) does not support it such that you will have to override the compiler (using the `CXX` environment variable).
+The version provided through Homebrew will work (or any of your choice) along with `--openmp=omp`.
+
+```bash
+## Default Homebrew path
+export CXX=/usr/local/opt/llvm/bin/clang++
+```
 
 
 Documentation

--- a/wscript
+++ b/wscript
@@ -115,7 +115,7 @@ def configure(conf):
 
     # ImageMagick / GraphicsMagick
     if distutils.spawn.find_executable('Magick++-config'):
-        conf.check_cfg(package='', path='Magick++-config', args='--cppflags --cxxflags --libs', uselib_store='MAGICK', mandatory=True)
+        conf.check_cfg(package='', path='Magick++-config', args='--cppflags --cxxflags --libs', uselib_store='MAGICK', mandatory=True, msg='Checking for ImageMagick/GraphicsMagick')
     else:
         image = conf.check_cfg(package='ImageMagick++', args='--cflags --libs', uselib_store='MAGICK', mandatory=False)
         graphics = conf.check_cfg(package='GraphicsMagick++', args='--cflags --libs', uselib_store='MAGICK', mandatory=False)

--- a/wscript
+++ b/wscript
@@ -59,6 +59,7 @@ def options(opt):
     opt.add_option('--disable-gcov', action='store_true', default=False, help='don''t use gcov in tests')
     opt.add_option('--disable-examples', action='store_true', default=False, help='disable building of examples')
     opt.add_option('--enable-openmp', action='store_true', default=False, help='enable use of OpenMP')
+    opt.add_option('--openmp', default='gomp', help='Specify OpenMP Library to use: omp, gomp (default), iomp..')
     opt.add_option('--jpeg', default='oj2', help='specify JPEG library to build with: oj1 or oj2 for OpenJPEG 1.5.x or OpenJPEG 2.1.x respectively')
     opt.add_option('--force-cpp11', action='store_true', default=False, help='force use of C++11')
 
@@ -94,7 +95,8 @@ def configure(conf):
 
     if conf.options.enable_openmp:
         conf.env.append_value('CXXFLAGS', ['-fopenmp', '-DLIBDCP_OPENMP'])
-        conf.env.LIB_OPENMP = ['gomp']
+        conf.env.LIB_OPENMP = [conf.options.openmp]
+        conf.env.append_value('LDFLAGS', ['-l%s' % conf.options.openmp])
         conf.check_cxx(cxxflags='-fopenmp', msg='Checking that compiler supports -fopenmp')
 
     if not conf.env.TARGET_WINDOWS:


### PR DESCRIPTION
I added the option to specify the openmp library to use.

At least when on macOS it's comfortable using the existing package managers and homebrew seems to have only libomp but not so much libgomp.

It's not doing any sanity checks, but is rather straight forward.

PLUS: Readme elaborations according to #3 
