### PR TITLE
Allow e.g. larger DKDMs for CPLs with 40+ unique sound and picture assets.

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -69,7 +69,7 @@ extern void init ();
 extern int base64_decode (std::string const & in, unsigned char* out, int out_length);
 extern boost::optional<boost::filesystem::path> relative_to_root (boost::filesystem::path root, boost::filesystem::path file);
 extern FILE * fopen_boost (boost::filesystem::path, std::string);
-extern std::string file_to_string (boost::filesystem::path, uintmax_t max_length = 65536);
+extern std::string file_to_string (boost::filesystem::path, uintmax_t max_length = 1048576);
 extern std::string private_key_fingerprint (std::string key);
 extern xmlpp::Node* find_child (xmlpp::Node const * node, std::string name);
 extern std::string openjpeg_version();


### PR DESCRIPTION
I've recently run into the error `Unexpectedly long file` when trying to generate KDMs for the CPL [adbcd644-1cb8-4b81-9479-793b5ad6beff.txt](https://github.com/cth103/libdcp/files/3869781/adbcd644-1cb8-4b81-9479-793b5ad6beff.txt). It has 74 sound and picture assets that are encrypted, causing the DKDM to be larger than the current limit of 64 KB (it's 81 KB to be precise).

Note that I don't expect to ever see a DKDM that's 1 MB big, but I don't see any harm in setting the limit this high either.



