### PR TITLE
Compilation issues

### DIFF
--- a/benchmark/wscript
+++ b/benchmark/wscript
@@ -35,7 +35,7 @@ def build(bld):
     for p in ['rgb_to_xyz', 'j2k_transcode']:
         obj = bld(features='cxx cxxprogram')
         obj.name = p
-        obj.uselib = 'BOOST_FILESYSTEM ASDCPLIB_CTH'
+        obj.uselib = 'BOOST_FILESYSTEM ASDCPLIB_CTH CXML'
         obj.cppflags = ['-g', '-O2']
         obj.use = 'libdcp%s' % bld.env.API_VERSION
         obj.source = "%s.cc" % p

--- a/libdcp-1.0.pc.in
+++ b/libdcp-1.0.pc.in
@@ -5,6 +5,6 @@ includedir=@includedir@
 Name: libdcp
 Description: DCP reading and writing library
 Version: @version@
-Requires: sigc++-2.0 openssl libxml++-2.6 xmlsec1 libasdcp-carl xerces-c
+Requires: sigc++-2.0 openssl libxml++-2.6 xmlsec1 libasdcp-cth xerces-c
 Libs: @libs@
 Cflags: -I${includedir}

--- a/src/util.cc
+++ b/src/util.cc
@@ -453,16 +453,17 @@ boost::filesystem::path dcp::directory_containing_executable ()
 
 boost::filesystem::path dcp::resources_directory ()
 {
-#if defined(LIBDCP_OSX)
-	return directory_containing_executable().parent_path() / "Resources";
-#elif defined(LIBDCP_WINDOWS)
-	return directory_containing_executable().parent_path();
-#else
 	/* We need a way to specify the tags directory for running un-installed binaries */
 	char* prefix = getenv("LIBDCP_RESOURCES");
 	if (prefix) {
 		return prefix;
 	}
+
+#if defined(LIBDCP_OSX)
+	return directory_containing_executable().parent_path() / "Resources";
+#elif defined(LIBDCP_WINDOWS)
+	return directory_containing_executable().parent_path();
+#else
 	return directory_containing_executable().parent_path() / "share" / "libdcp";
 #endif
 }

--- a/src/wscript
+++ b/src/wscript
@@ -158,6 +158,7 @@ def build(bld):
               metadata.h
               mono_picture_asset.h
               mono_picture_asset_reader.h
+              mono_picture_asset_writer.h
               mono_picture_frame.h
               modified_gamma_transfer_function.h
               mxf.h

--- a/wscript
+++ b/wscript
@@ -54,7 +54,7 @@ def options(opt):
     opt.load('compiler_cxx')
     opt.add_option('--target-windows', action='store_true', default=False, help='set up to do a cross-compile to Windows')
     opt.add_option('--enable-debug', action='store_true', default=False, help='build with debugging information and without optimisation')
-    opt.add_option('--static', action='store_true', default=False, help='build libdcp statically, and link statically to openjpeg, cxml, asdcplib-carl')
+    opt.add_option('--static', action='store_true', default=False, help='build libdcp statically, and link statically to openjpeg, cxml, asdcplib-cth')
     opt.add_option('--disable-tests', action='store_true', default=False, help='disable building of tests')
     opt.add_option('--disable-benchmarks', action='store_true', default=False, help='disable building of benchmarks')
     opt.add_option('--disable-gcov', action='store_true', default=False, help='don''t use gcov in tests')
@@ -141,9 +141,9 @@ def configure(conf):
         elif conf.options.jpeg == 'oj1':
             conf.check_cfg(package='libopenjpeg1', args='--cflags', atleast_version='1.5.0', uselib_store='OPENJPEG', mandatory=True)
             conf.env.STLIB_OPENJPEG = ['openjpeg']
-        conf.check_cfg(package='libasdcp-carl', atleast_version='0.1.3', args='--cflags', uselib_store='ASDCPLIB_CTH', mandatory=True)
+        conf.check_cfg(package='libasdcp-cth', atleast_version='0.1.3', args='--cflags', uselib_store='ASDCPLIB_CTH', mandatory=True)
         conf.env.HAVE_ASDCPLIB_CTH = 1
-        conf.env.STLIB_ASDCPLIB_CTH = ['asdcp-carl', 'kumu-carl']
+        conf.env.STLIB_ASDCPLIB_CTH = ['asdcp-cth', 'kumu-carl']
         conf.env.HAVE_CXML = 1
         conf.env.LIB_CXML = ['xml++-2.6', 'glibmm-2.4']
         conf.env.STLIB_CXML = ['cxml']
@@ -154,7 +154,7 @@ def configure(conf):
             conf.check_cfg(package='libopenjp2', args='--cflags --libs', atleast_version='2.1.0', uselib_store='OPENJPEG', mandatory=True)
         elif conf.options.jpeg == 'oj1':
             conf.check_cfg(package='libopenjpeg1', args='--cflags --libs', atleast_version='1.5.0', uselib_store='OPENJPEG', mandatory=True)
-        conf.check_cfg(package='libasdcp-carl', atleast_version='0.1.3', args='--cflags --libs', uselib_store='ASDCPLIB_CTH', mandatory=True)
+        conf.check_cfg(package='libasdcp-cth', atleast_version='0.1.3', args='--cflags --libs', uselib_store='ASDCPLIB_CTH', mandatory=True)
         conf.check_cfg(package='libcxml', atleast_version='0.17.0', args='--cflags --libs', uselib_store='CXML', mandatory=True)
         conf.check_cfg(package='xerces-c', args='--cflags --libs', uselib_store='XERCES', mandatory=True)
 


### PR DESCRIPTION
I encountered some small issues while trying to compile `libdcp` and to embed the `make_dcp` example in a different project. E.g. the `wscript` looks for `libasdcp-carl` but the README points to https://github.com/cth103/asdcplib-cth/tree/cth which builds as `libasdcp-cth`. Or should we actually be using https://github.com/cth103/asdcplib/tree/carl, which I just noticed also exists?